### PR TITLE
add caching parameter to node setup action

### DIFF
--- a/.github/workflows/run-tests-backend.yml
+++ b/.github/workflows/run-tests-backend.yml
@@ -2,9 +2,13 @@ name: Backend CI pipeline
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+    paths: "backend/**"
   pull_request:
-    branches: [master]
+    branches:
+      - master
+    paths: "backend/**"
 
 jobs:
   build:

--- a/.github/workflows/run-tests-frontend.yml
+++ b/.github/workflows/run-tests-frontend.yml
@@ -2,9 +2,13 @@ name: Frontend CI pipeline
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+    paths: "skillswipe/**"
   pull_request:
-    branches: [master]
+    branches:
+      - master
+    paths: "skillswipe/**"
 
 jobs:
   build:


### PR DESCRIPTION
- Add cache to npm install for both project during github action build
- Add per project trigger, ie backend build won't be triggered for frontend and vice versa
- Remove separate `npm run test` from backend because `npm run test:cov` is the same but with coverage criteria