### PR TITLE
Implemented filter functionality in openJobs page

### DIFF
--- a/skillswipe/src/pages/openJobs.tsx
+++ b/skillswipe/src/pages/openJobs.tsx
@@ -94,16 +94,16 @@ const findJob = () => {
       console.log('Filtering ...');
       switch (filterValue) {
         case 'full-time':
-            filteredJobs = filteredJobs.filter((job) => job.jobType === 'full-time');
+            filteredJobs = filteredJobs.filter((job) => job.jobType === 'full-time' as string);
             break;
         case 'part-time':
-            filteredJobs = filteredJobs.filter((job) => job.jobType === 'part-time');
+            filteredJobs = filteredJobs.filter((job) => job.jobType === 'part-time' as string);
             break;
         case 'contract':
-            filteredJobs = filteredJobs.filter((job) => job.jobType === 'contract');
+            filteredJobs = filteredJobs.filter((job) => job.jobType === 'contract' as string);
             break;
         case 'other':
-            filteredJobs = filteredJobs.filter((job) => job.jobType === 'other');
+            filteredJobs = filteredJobs.filter((job) => job.jobType === 'other' as string );
             break;
 
         default:


### PR DESCRIPTION
The user can now filter jobs type and sort them by starting date or salary on openJobs Page. A user can also look for jobs by type like full time or part-time or contract etc.