### PR TITLE
Feature/remove_cover_pic

### DIFF
--- a/skillswipe/src/pages/api/api.ts
+++ b/skillswipe/src/pages/api/api.ts
@@ -144,8 +144,10 @@ export const editLanguages = async (token: any, UpdatedUser: any) => {
   })
 }
 
-export const removeProfilepic = async (token: any) => {
-  return axios.delete(`${URL}/user/profilePic`, {
+
+
+export const removeCoverpic = async (token: any) => {
+  return axios.delete(`${URL}/user/coverPic`, {
     headers: {
       authorization: `Bearer ${token}`,
     },

--- a/skillswipe/src/pages/profile/editProfile.tsx
+++ b/skillswipe/src/pages/profile/editProfile.tsx
@@ -6,7 +6,7 @@ import Layout from '@/components/Layout'
 import NavBar from '@/components/NavBar'
 import { Box, color, Heading, Stack } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
-import { editPersonalInformation, removeProfilepic } from '../api/api'
+import { editPersonalInformation, removeCoverpic } from '../api/api'
 
 import EducationHistoryBox from '@/components/EditProfile/EductationHistoryBox'
 import ExperienceBox from '@/components/EditProfile/ExperienceBox'
@@ -82,13 +82,15 @@ const EditProfile = () => {
     }
   }
 
-  const removeUserProfilepic = () => {
+  
+
+  const removeUserCoverpic = () => {
     const token = localStorage.getItem('jwt')
-    removeProfilepic(token)
+    removeCoverpic(token)
       .then((response) => {
         console.log(response)
-        setPic({ ...Pic, profilePic: response.data.profilePic })
-        toast('Successfully Removed Profile Picture')
+        setPic({ ...Pic, coverPic: response.data.coverPic })
+        toast('Successfully Removed Cover Picture')
       })
       .catch((error) => {
         toast(error.message)
@@ -162,24 +164,6 @@ const EditProfile = () => {
                 />
               </label>
             </button>
-            <button style={{ position: 'absolute', top: '0', right: '0' }}>
-    <img
-      src="https://img.icons8.com/material-sharp/512/trash.png"
-      alt="Delete Icon"
-      style={{
-        height: '35px',
-        width: '35px',
-        borderRadius: '100%',
-        backgroundColor: 'white',
-        padding: "1px",
-        margin: "2px",
-        border: "3px solid black"
-        
-      }}
-      // add an onClick handler to delete the profile pic
-      onClick={removeUserProfilepic}
-    />
-  </button>
             <a onClick={clickProfile}>
               <img
                 alt="image"
@@ -265,6 +249,35 @@ const EditProfile = () => {
               style={{ display: 'none' }}
               onChange={coverImageHandler}
             />
+
+{ Pic.coverPic ?  (
+              
+              
+              <button style={{ position: 'absolute', bottom: '-10px', left: '-5px' }}>
+         
+                <img
+           src="https://img.icons8.com/material-sharp/512/trash.png"
+           alt="Delete Icon"
+           style={{
+             height: '35px',
+             width: '35px',
+             borderRadius: '100%',
+             backgroundColor: 'white',
+             padding: "1px",
+             margin: "2px",
+             border: "3px solid black"
+             
+            }}
+            // add an onClick handler to delete the profile pic
+            onClick={removeUserCoverpic}
+            />
+            
+       </button>
+        
+       
+            ) : null
+     
+       }
           </div>
         </Stack>
 


### PR DESCRIPTION
This pull request implements a new feature that allows the user to delete their cover pic by clicking on an Icon button on the editProfile page. The Icon button is styled with a trash icon and a white background. The button has an onClick handler that calls a function to remove the cover pic from the database and update the state. The button is only visible if the user has a profile pic uploaded.