### PR TITLE
Add Icon button to delete profile pic on editProfile page

### DIFF
--- a/skillswipe/src/pages/api/api.ts
+++ b/skillswipe/src/pages/api/api.ts
@@ -168,7 +168,13 @@ export const removeCoverpic = async (token: any) => {
   })
 }
 
-
+export const removeProfilepic = async (token: any) => {
+  return axios.delete(`${URL}/user/profilePic`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  })
+}
 
 export const search = async (token: any, query: string) => {
   return axios.get(`${URL}/search?query=${query}`, {

--- a/skillswipe/src/pages/profile/editProfile.tsx
+++ b/skillswipe/src/pages/profile/editProfile.tsx
@@ -6,7 +6,7 @@ import Layout from '@/components/Layout'
 import NavBar from '@/components/NavBar'
 import { Box, color, Heading, Stack } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
-import { editPersonalInformation, removeCoverpic } from '../api/api'
+import { editPersonalInformation, removeCoverpic, removeProfilepic } from '../api/api'
 
 import EducationHistoryBox from '@/components/EditProfile/EductationHistoryBox'
 import ExperienceBox from '@/components/EditProfile/ExperienceBox'
@@ -97,6 +97,18 @@ const EditProfile = () => {
       })
   }
 
+  const removeUserProfilepic = () => {
+    const token = localStorage.getItem('jwt')
+    removeProfilepic(token)
+      .then((response) => {
+        console.log(response)
+        setPic({ ...Pic, profilePic: response.data.profilePic })
+        toast('Successfully Removed Cover Picture')
+      })
+      .catch((error) => {
+        toast(error.message)
+      })
+  }
 
   const clickCover = () => {
     document.getElementById('file-input-coverPic')?.click()
@@ -190,34 +202,34 @@ const EditProfile = () => {
               style={{ display: 'none' }}
               onChange={ProfileImageHandler}
               />
-            { Pic.profilePic ?  (
-              
-              
-            <button style={{ position: 'absolute', top: '0', right: '0' }}>
-       
-              <img
-         src="https://img.icons8.com/material-sharp/512/trash.png"
-         alt="Delete Icon"
-         style={{
-           height: '35px',
-           width: '35px',
-           borderRadius: '100%',
-           backgroundColor: 'white',
-           padding: "1px",
-           margin: "2px",
-           border: "3px solid black"
-           
-          }}
-          // add an onClick handler to delete the profile pic
-          onClick={removeUserProfilepic}
-          />
-          
-     </button>
-      
-     
-          ) : null
-   
-     }
+            {Pic.profilePic ? (
+
+
+              <button style={{ position: 'absolute', top: '0', right: '0' }}>
+
+                <img
+                  src="https://img.icons8.com/material-sharp/512/trash.png"
+                  alt="Delete Icon"
+                  style={{
+                    height: '35px',
+                    width: '35px',
+                    borderRadius: '100%',
+                    backgroundColor: 'white',
+                    padding: "1px",
+                    margin: "2px",
+                    border: "3px solid black"
+
+                  }}
+                  // add an onClick handler to delete the profile pic
+                  onClick={removeUserProfilepic}
+                />
+
+              </button>
+
+
+            ) : null
+
+            }
           </div>
 
           {/* cover photo */}


### PR DESCRIPTION
This pull request implements the API in api.ts for the new feature that allows the user to delete their profile pic by clicking on an Icon button on the editProfile page. The button has an onClick handler that calls a function to remove the profile pic from the database and update the state. The button is only visible if the user has a profile pic uploaded.